### PR TITLE
Getting all Favorites in db

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,10 +10,14 @@ const bodyParser = require("body-parser");
 app.use(bodyParser.json()); app.use(bodyParser.urlencoded({extended: true}));
 
 var indexRouter = require('./routes/index');
+var favoritesRouter = require('./routes/api/v1/favorites');
 
 app.use('/', indexRouter);
+app.use('/api/v1/favorites', favoritesRouter);
 
-app.set("port", process.env.PORT || 3000);
-app.listen(app.get('port')); console.log(`Running on port ${app.get('port')}`);
+if (process.env.NODE_ENV !== 'test') {
+  app.set("port", process.env.PORT || 3000);
+  app.listen(app.get('port')); console.log(`Running on port ${app.get('port')}`);
+}
 
 module.exports = app;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,0 +1,19 @@
+var express = require('express');
+var router = express.Router();
+
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+
+router.get('/', (request, response) => {
+  database('favorites').select().then(favs => {
+    if (favs.length) {
+      response.status(200).json(favs);
+    } else {
+      response.status(404).json({error: "No favorites"});
+    }
+  }).catch(err => response.status(404).json({error: err}))
+});
+
+module.exports = router;

--- a/tests/all-favs.spec.js
+++ b/tests/all-favs.spec.js
@@ -1,0 +1,40 @@
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test the favorites endpoints', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table favorites cascade');
+  });
+
+  describe('Test getting all favorites', () => {
+    it('It should respond with all favs in db', async () => {
+      await database('favorites').insert({
+        title: 'We Will Rock You',
+        artistName: 'Queen',
+        genre: 'Rock',
+        rating: 88 }, 'id');
+      await database('favorites').insert({
+        title: 'Careless Whisper',
+        artistName: 'George Michael',
+        rating: 93 }, 'id');
+
+      const res = await request(app)
+        .get("/api/v1/favorites");
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.length).toBe(2);
+    });
+
+    it('It should respond with a 404 if no favs in db', async () => {
+      const res = await request(app)
+        .get("/api/v1/favorites");
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toEqual({ error: "No favorites" });
+    });
+  });
+})


### PR DESCRIPTION
This closes #11 closes #10 

Tests: Add test happy/sad paths for getting all favorites in the database
Routes: Add `/api/v1/favorites` GET route