### PR TITLE
Getting all playlists in the database - Endpoint

### DIFF
--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -5,6 +5,16 @@ const environment = process.env.NODE_ENV || 'development';
 const configuration = require('../../../knexfile')[environment];
 const database = require('knex')(configuration);
 
+router.get('/', (req, res) => {
+  database('playlists').select().then(playlists => {
+    if (playlists.length) {
+      res.status(200).json(playlists);
+    } else {
+      res.status(404).json({error: "No playlists currently"});
+    }
+  }).catch(err => res.status(404).json({error: err}))
+});
+
 router.post('/', (req, res) => {
   if (req.body.title) {
     database('playlists').insert({title: req.body.title}, 'id').then(playlist => {

--- a/tests/all-playlists.spec.js
+++ b/tests/all-playlists.spec.js
@@ -1,0 +1,33 @@
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test the favorites endpoints', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists cascade');
+  });
+
+  describe('Test getting all playlists', () => {
+    it('It should respond with all playlists in db', async () => {
+      await database('playlists').insert({title: 'Workout Jams'}, 'id');
+      await database('playlists').insert({title: 'Sad Playlist'}, 'id');
+
+      const res = await request(app)
+        .get("/api/v1/playlists");
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.length).toBe(2);
+    });
+
+    it('It should respond with a 404 if no favs in db', async () => {
+      const res = await request(app)
+        .get("/api/v1/playlists");
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toEqual({ error: "No playlists currently" });
+    });
+  });
+})


### PR DESCRIPTION
This closes #27 closes #28 
Tests: Happy/sad paths for getting all playlists
Routes: add `api/v1/playlists` GET route