### PR TITLE
Delete Playlist Record by ID

### DIFF
--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -27,4 +27,14 @@ router.post('/', (req, res) => {
   }
 });
 
+router.delete('/:id', (req, res) => {
+  database('playlists').del().where({id: req.params.id}).then(playlist => {
+    if (playlist) {
+      res.status(204).send();
+    } else {
+      res.status(404).json({error: "Playlist not found"});
+    }
+  }).catch(err => res.status(404).json({error: err}))
+});
+
 module.exports = router;

--- a/tests/delete_playlist.spec.js
+++ b/tests/delete_playlist.spec.js
@@ -1,0 +1,31 @@
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test the playlists endpoints', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists cascade');
+  });
+
+  describe('Test deleting specific playlist by id', () => {
+    it('Should respond with a 204 if deleted', async () => {
+      await database('playlists').insert({title: 'Workout Jams', id: 1});
+
+      const res = await request(app)
+        .delete('/api/v1/playlists/1');
+
+      expect(res.statusCode).toBe(204);
+    })
+
+    it('Should respond with a 404 if fav not found in db', async () => {
+      const res = await request(app)
+        .delete('/api/v1/playlists/1');
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toEqual({error: "Playlist not found"});
+    })
+  })
+})


### PR DESCRIPTION
This closes #32 closes #33 

Test: Add tests to verify the deleting of a playlist record from the database by its ID. Tests sad path if a record cannot be found. 

Route: /api/v1/playlists/:id  DELETE