### PR TITLE
Update Playlist Resources - Endpoint

### DIFF
--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -27,6 +27,18 @@ router.post('/', (req, res) => {
   }
 });
 
+router.put('/:id', (req, res) => {
+  database('playlists').where({id: req.params.id}).update(req.body).then(playlist => {
+    if (playlist) {
+      database('playlists').where({id: req.params.id}).first().then(playlist => {
+        res.status(201).send(playlist);
+      })
+    } else {
+      res.status(404).json({error: "Playlist not found"});
+    }
+  }).catch(err => res.status(404).json({error: "Playlist not found/Title is not unique"}))
+});
+
 router.delete('/:id', (req, res) => {
   database('playlists').del().where({id: req.params.id}).then(playlist => {
     if (playlist) {

--- a/tests/put-playlist.spec.js
+++ b/tests/put-playlist.spec.js
@@ -1,0 +1,54 @@
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test the playlists endpoints', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists cascade');
+  });
+
+  describe('Test updating specific playlist by id', () => {
+    it('Should respond with a 201 if updated', async () => {
+      await database('playlists').insert({id: 2, title: 'Running'});
+
+      const res = await request(app)
+        .put('/api/v1/playlists/2')
+        .send({
+          title: "Running Mix",
+          createdAt: '2019-11-26T16:03:43.000Z',
+          updatedAt: '2019-11-26T16:03:43.000Z'
+        })
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.title).toEqual('Running Mix');
+      expect(res.body.createdAt).toEqual('2019-11-26T16:03:43.000Z');
+      expect(res.body.updatedAt).toEqual('2019-11-26T16:03:43.000Z');
+    })
+
+    it('Should respond with a 201 if updated', async () => {
+      await database('playlists').insert({id: 1, title: 'Running'});
+      await database('playlists').insert({id: 2, title: 'Running MIX'});
+
+      const res = await request(app)
+        .put('/api/v1/playlists/2')
+        .send({
+          title: "Running",
+          createdAt: '2019-11-26T16:03:43+00:00',
+          updatedAt: '2019-11-26T16:03:45+00:00'
+        })
+
+      expect(res.body).toEqual({error: 'Playlist not found/Title is not unique'});
+    })
+
+    it('Should respond with a 404 if fav not found in db', async () => {
+      const res = await request(app)
+        .put('/api/v1/playlists/1000');
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toEqual({error: "Playlist not found/Title is not unique"});
+    })
+  })
+})


### PR DESCRIPTION
This closes #31 closes #30 
Test: happy and sad paths for put on playlist resources
Route: add `api/v1/playlists` `PUT` route