### PR TITLE
GET Route for Playlist Favorites

### DIFF
--- a/db/migrations/20200211141053_playlist_favorites.js
+++ b/db/migrations/20200211141053_playlist_favorites.js
@@ -1,14 +1,14 @@
 exports.up = function(knex) {
   return knex.schema.createTable('playlist_favorites', function(table) {
     table.increments('id').primary().notNullable();
-    table.integer('playlistId').unsigned().references('id').inTable('playlists').notNullable();
-    table.integer('favoriteId').unsigned().references('id').inTable('favorites').notNullable();
-    table.unique(['playlistId', 'favoriteId'])
+    table.integer('playlist_id').unsigned().references('id').inTable('playlists').notNullable();
+    table.integer('favorite_id').unsigned().references('id').inTable('favorites').notNullable();
+    table.unique(['playlist_id', 'favorite_id'])
   })
 };
 
 exports.down = function(knex) {
   return knex.schema.table('playlist_favorites', function(table) {
-    table.dropUnique(['playlistId', 'favoriteId'])
+    table.dropUnique(['playlist_id', 'favorite_id'])
   }).dropTable('playlist_favorites')
 };

--- a/helpers/favorites.js
+++ b/helpers/favorites.js
@@ -1,5 +1,5 @@
 function formatFav(fav) {
-  delete fav.createdAt; delete fav.updatedAt;
+  delete fav.createdAt; delete fav.updatedAt; delete fav.playlist_id; delete fav.favorite_id;
   return fav;
 }
 

--- a/helpers/format_playlist.js
+++ b/helpers/format_playlist.js
@@ -1,0 +1,16 @@
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+const formatFav = require('./favorites')
+
+
+async function formatPlaylist(playlist) {
+  playlist.favorites = await database.raw(`SELECT *, favorites.id FROM favorites INNER JOIN playlist_favorites ON favorites.id = playlist_favorites.favorite_id WHERE playlist_favorites.playlist_id = ${playlist.id}`).then(data => data.rows.map(fav => {
+    return formatFav(fav)
+  }))
+  playlist.songCount = await database.raw(`SELECT COUNT(favorites) AS songCount FROM favorites INNER JOIN playlist_favorites ON favorites.id = playlist_favorites.favorite_id WHERE playlist_favorites.playlist_id = ${playlist.id}`).then(data => parseInt(data.rows[0].songcount))
+  playlist.songAvgRating = await database.raw(`SELECT AVG(favorites.rating) AS songAvgRating FROM favorites INNER JOIN playlist_favorites ON favorites.id = playlist_favorites.favorite_id WHERE playlist_favorites.playlist_id = ${playlist.id}`).then(data => parseFloat(data.rows[0].songavgrating))
+  return playlist
+}
+
+module.exports = formatPlaylist

--- a/tests/playlist_favorites/all_playlist_favorites.spec.js
+++ b/tests/playlist_favorites/all_playlist_favorites.spec.js
@@ -48,4 +48,12 @@ describe('Test the playlist favorites endpoints', () => {
       expect(res.body.favorites[1].rating).toBe(93);
     });
   })
+
+  it('It should respond with a 404 if no favs in db', async () => {
+    const res = await request(app)
+      .get("/api/v1/playlists/2500/favorites");
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({error: 'Playlist not found'});
+  });
 })

--- a/tests/playlist_favorites/all_playlist_favorites.spec.js
+++ b/tests/playlist_favorites/all_playlist_favorites.spec.js
@@ -1,0 +1,51 @@
+var request = require("supertest");
+var app = require('../../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test the playlist favorites endpoints', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlist_favorites cascade');
+    await database.raw('truncate table playlists cascade');
+    await database.raw('truncate table favorites cascade');
+  });
+
+  describe('Test getting all playlist favorites', () => {
+    it('Should respond with a 200 and success playlist body with favorites data', async () => {
+      await database('playlists').insert({title: 'Workout Jams', id: 1});
+      await database('favorites').insert([{
+        id: 1,
+        title: 'We Will Rock You',
+        artistName: 'Queen',
+        genre: 'Rock',
+        rating: 88 },
+        {
+        id: 2,
+        title: 'Careless Whisper',
+        artistName: 'George Michael',
+        genre: 'Classical',
+        rating: 93 }]);
+
+      await request(app).post('/api/v1/playlists/1/favorites/1');
+      await request(app).post('/api/v1/playlists/1/favorites/2');
+
+      const res = await request(app).get("/api/v1/playlists/1/favorites");
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.title).toBe('Workout Jams');
+      expect(res.body.songCount).toBe(2);
+      expect(res.body.songAvgRating).toBe(90.5);
+      expect(res.body.favorites.length).toBe(2);
+      expect(res.body.favorites[0].title).toBe('We Will Rock You');
+      expect(res.body.favorites[0].artistName).toBe('Queen');
+      expect(res.body.favorites[0].genre).toBe('Rock');
+      expect(res.body.favorites[0].rating).toBe(88);
+      expect(res.body.favorites[1].title).toBe('Careless Whisper');
+      expect(res.body.favorites[1].artistName).toBe('George Michael');
+      expect(res.body.favorites[1].genre).toBe('Classical');
+      expect(res.body.favorites[1].rating).toBe(93);
+    });
+  })
+})


### PR DESCRIPTION
This closes #43  and closes #44 

Tests: Happy and Sad path
Route: GET playlists/:id/favorites
Helper: Format playlist_favorites to include song count and average song rating. 